### PR TITLE
Fix adding subviews into cell content view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 xcuserdata
+.DS_Store

--- a/MVCTodo/Common View Controllers/ListViewController.swift
+++ b/MVCTodo/Common View Controllers/ListViewController.swift
@@ -107,6 +107,10 @@ extension ListViewController: UITableViewDataSource, UITableViewDelegate {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
         
         let row = content[indexPath.row]
+
+        if !cell.contentView.subviews.isEmpty && !row.view.isContainedWithin(cell.contentView) {
+            cell.contentView.removeAllSubviews()
+        }
         
         cell.contentView.embedSubview(row.view)
         

--- a/MVCTodo/Extensions/UIView.swift
+++ b/MVCTodo/Extensions/UIView.swift
@@ -40,5 +40,8 @@ extension UIView {
         }
         return false
     }
-    
+
+    func removeAllSubviews() {
+        subviews.forEach { $0.removeFromSuperview() }
+    }
 }


### PR DESCRIPTION
In some cases is not the previous view removed from cell content view and it is added another one. The result is that the cell content view contains two views of different view controllers. This issue can be replicated in these steps:
1. Create two differently named lists.
2. Remove first list.
3. Select the remaining list - then both views are visible and their titles are overlapping.